### PR TITLE
Feature/master/wp jwt content type to introspect

### DIFF
--- a/oauth/jwt_validator.py
+++ b/oauth/jwt_validator.py
@@ -62,8 +62,9 @@ class JwtValidator:
             print "Invalid audience, no audience in payload"
             return {"active": False}
 
+        # FIXME: Curity has a bug that causes it to use space-separated values for audience when it should in fact
+        # be an array. When that bug is fixed, this too should be fixed.
         aud = re.split("\s+", payload['aud'])
-
 
         if self.aud not in aud:
             print "Invalid audience %s, expected %s" % (payload['aud'], self.aud)

--- a/oauth/oauth_filter.py
+++ b/oauth/oauth_filter.py
@@ -66,14 +66,18 @@ class OAuthFilter:
         :return: the stripped token
         """
         authorization_header = request.headers.get("authorization")
+
         if authorization_header is None:
             abort(401)
 
+        authorization_header_parts = re.split("\s+", authorization_header)
+        authorization_type = authorization_header_parts[0].lower()
+
         # Extract the token from the Bearer string
-        if not authorization_header.startswith("Bearer "):
+        if authorization_type != "bearer":
             abort(401)
-        token = authorization_header.replace("Bearer ", "")
-        return token.strip()
+
+        return authorization_header_parts[1] if len(authorization_header_parts) >= 2 else None
 
     def _authorize(self, scope, endpoint_scopes=None):
         if isinstance(scope, (list, tuple)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+requests
 Flask==0.10.1
 pyjwkest==1.0.6


### PR DESCRIPTION
This PR implements the phantom token pattern using Curity's new feature to introspect ref tokens and return JWTs directly when the client accepts `application/json`. While updating that request/response to introspection, I also revisited the caching and handling of the `Authorization` header value. Few other minor fixes as well.