### PR TITLE
Feat/pass claims in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,18 +114,13 @@ if __name__ == '__main__':
              ssl_context="adhoc")
 ```
 
-## The g.user variable
-
-When the filter accepts the request, it sets the `g.user` context local variable for that request with the username that
-has been authenticated through the token. This is then accessible in the route.
-
-*Future updates of this filter should add more information from the token into the context.*
-
 
 ## Access token claims in Request object
 
-When the filter accepts the request, it sets the `request.foil_claims` context local variable for that request with all
+When the filter accepts the request, it sets the `request.claims` context local variable for that request with all
 the token claims. For JWT tokens, this is the JWT payload and for opaque tokens the introspection response. 
+
+For example, in the subject of the Authorization can be accessed like so `request.claims.sub` 
 
 ## Handling errors
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ def hello_world():
     return json.dumps({"hello": g.user})
 ```
 
+### Authorizing the request based on scopes
+
+The scope parameter of the protect decorator must either be a list or a space separated string:
+``` 
+["scope1", "scope2]
+or 
+"scope1 scope2"
+```
+
+### Authorizing the request based on claims
+
+The incoming request can also be authorized based on claims, or a combination of claims and scopes.
+The claims parameter of the protect decorator method has to be a `dict`, with keys the claims that are required 
+for the request to be allowed. The value `None` instructs the filter to not check the value for the specific claim. 
+
+```python
+# Only allow requests where the incoming access token has the scope read and it contains a claim named MyGoodClaim
+@_oauth.protect(scope=["read"], claims={"MyGoodClaim": None})
+```
+```python
+# Only allow requests where the incoming access token has the scope write and it contains a claim named MyGoodClaim with value MyGoodValue
+@_oauth.protect(scope=["write"], claims={"MyGoodClaim": "MyGoodValue"})
+```
+
+
 ## Initializing the filter
 
 **Filter global variable**

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ has been authenticated through the token. This is then accessible in the route.
 *Future updates of this filter should add more information from the token into the context.*
 
 
+## Access token claims in Request object
+
+When the filter accepts the request, it sets the `request.foil_claims` context local variable for that request with all
+the token claims. For JWT tokens, this is the JWT payload and for opaque tokens the introspection response. 
+
 ## Handling errors
 
 The filter may abort the request if the Access token is invalid or if the scopes in the access token doesn't match the

--- a/flask_of_oil/jwt_validator.py
+++ b/flask_of_oil/jwt_validator.py
@@ -109,11 +109,7 @@ class JwtValidator:
         if now >= exp:
             return {"active": False}
         else:
-            return {
-                "subject": payload['sub'],
-                "scope": scope,
-                "active": True
-            }
+            return payload
 
     def get_jwks_data(self):
         ctx = ssl.create_default_context()

--- a/flask_of_oil/oauth_filter.py
+++ b/flask_of_oil/oauth_filter.py
@@ -141,6 +141,7 @@ class OAuthFilter:
             abort(make_response("Forbidden", 403))
 
         # Set the user info in a context global variable
-        g.user = validated_token['subject']
+        g.user = validated_token['sub']
+        request.foil_claims = validated_token
 
         return None

--- a/flask_of_oil/oauth_filter.py
+++ b/flask_of_oil/oauth_filter.py
@@ -17,7 +17,7 @@
 import logging
 from functools import wraps
 
-from flask import request, abort, g, make_response
+from flask import request, abort, make_response
 
 from flask_of_oil.jwt_validator import JwtValidator
 from flask_of_oil.opaque_validator import OpaqueValidator
@@ -147,7 +147,6 @@ class OAuthFilter:
             abort(make_response("Forbidden", 403))
 
         # Set the user info in a context global variable
-        g.user = validated_token['sub']
-        request.foil_claims = validated_token
+        request.claims = validated_token
 
         return None

--- a/flask_of_oil/opaque_validator.py
+++ b/flask_of_oil/opaque_validator.py
@@ -104,9 +104,7 @@ class OpaqueValidator:
         if cached_response is not None:
             if cached_response['active']:
                 if cached_response['exp'] >= now:
-                    return {"subject": cached_response['sub'],
-                            "scope": cached_response['scope'],
-                            "active": True}
+                    return cached_response
             else:
                 return dict(active=False)
 
@@ -140,7 +138,4 @@ class OpaqueValidator:
         if 'scope' not in introspect_response:
             raise OpaqueValidatorException("Missing scope field in introspection response")
 
-        return {"subject": introspect_response['sub'],
-                "scope": introspect_response['scope'],
-                "cnf": introspect_response.get("cnf", ""),
-                "active": True}
+        return introspect_response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests
+requests==2.22.0
 cachelib==0.1
-Flask==0.10.1
-pyjwkest==1.0.6
+Flask==1.1.1
+pyjwkest==1.4.2


### PR DESCRIPTION
This PR adds the following:

- Add the full introspection response in the request object (request.foil_claims)
- Add the JWT Payload (in case of JWT token) in the request object (request.foil_claims)
- Accept requests that have the access token in a query parameter instead of the Authorization header
- Update requirements