### PR TITLE
Numerous improvements

### DIFF
--- a/flask_of_oil/jwt_validator.py
+++ b/flask_of_oil/jwt_validator.py
@@ -68,7 +68,10 @@ class JwtValidator:
         if not isinstance(aud, list):
             aud = [aud]
 
-        if self.aud not in aud:
+        if not isinstance(self.aud, list):
+            self.aud = [self.aud]
+
+        if len(set(self.aud)&set(aud)) == 0:
             self.logger.debug("Invalid audience %s, expected %s" % (aud, self.aud))
             return {"active": False}
 


### PR DESCRIPTION
Hi

I have made a number of improvements so that this fits in our environment. I have tried to maintain backwards compatibility but lack of unit tests has made it a little difficult so this would probably need a little testing.

Changes made:

- allow list of audiences to be checked, not just single
- configure_with_multiple_jwt_issuers() can now be called with a list of dicts for issuers, instead of strings, in the format:
```python
{
  'url': str, # complete url to the jwks file
  'name': str, # should match the iss claim,
  'audience': str|list[str] # audiences to allow from this issuer
}
```
- _authorize() (and calling functions) now accept an optional audience parameter allowing checks for a specific aud on decorators, etc
- claims that are lists can now be checked with _authorize()
- prevent exception if scope claim is not present